### PR TITLE
hotfix - refactor solution for management of tm keys

### DIFF
--- a/application/app/Http/Controllers/API/CatToolController.php
+++ b/application/app/Http/Controllers/API/CatToolController.php
@@ -39,6 +39,17 @@ class CatToolController extends Controller
         responses: [new OAH\Forbidden, new OAH\Unauthorized, new OAH\Invalid, new OAH\InvalidTmKeys]
     )]
     #[OA\Response(response: Response::HTTP_CREATED, description: 'CAT tool was setup')]
+    #[OA\Response(
+        response: Response::HTTP_UNPROCESSABLE_ENTITY,
+        description: 'Sub project TM keys validation failed',
+        content: new OA\JsonContent(required: ['message'],
+            properties: [
+                new OA\Property(property: 'message', type: 'string'),
+            ],
+            type: 'object',
+            example: ['message' => 'Project should have at least one TM key || Project should have not more than 10 TM keys || Not more than two translation memories can be writable || At least one TM should be writable']
+        )
+    )]
     public function setup(CatToolSetupRequest $request): \Illuminate\Http\Response
     {
         $subProject = $this->getSubProject($request->validated('sub_project_id'));

--- a/application/app/Http/Controllers/API/CatToolTmKeyController.php
+++ b/application/app/Http/Controllers/API/CatToolTmKeyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Http\OpenApiHelpers as OAH;
 use App\Http\Requests\API\CatToolTmKeysSyncRequest;
+use App\Http\Requests\API\CatToolTmKeyToggleIsWritableRequest;
 use App\Http\Requests\API\TmKeySubProjectListRequest;
 use App\Http\Resources\API\CatToolTmKeyResource;
 use App\Http\Resources\API\SubProjectResource;
@@ -70,7 +71,7 @@ class CatToolTmKeyController extends Controller
 
         $query = SubProject::withGlobalScope('policy', SubProjectPolicy::scope())
             ->whereRelation('catToolTmKeys', 'key', $request->route('key'))
-        ->orderBy('created_at', 'desc');
+            ->orderBy('created_at', 'desc');
 
         return SubProjectResource::collection($query->paginate($request->get('per_page', 10)));
     }
@@ -80,7 +81,7 @@ class CatToolTmKeyController extends Controller
      */
     #[OA\Post(
         path: '/tm-keys/sync',
-        summary: 'Add new/delete missing/update existing TM keys for the sub-project',
+        summary: 'Add new/delete missing TM keys for the sub-project',
         requestBody: new OAH\RequestBody(CatToolTmKeysSyncRequest::class),
         tags: ['TM keys'],
         responses: [new OAH\NotFound, new OAH\Forbidden, new OAH\Unauthorized, new OAH\InvalidTmKeys]
@@ -110,15 +111,6 @@ class CatToolTmKeyController extends Controller
                         ])->saveOrFail();
                 });
 
-            // Update existing
-            $receivedTmKeysData->keys()->intersect($existingTmKeys->keys())
-                ->each(function (string $existingTmKeyKey) use ($existingTmKeys, $receivedTmKeysData) {
-                    /** @var CatToolTmKey $existingTmKey */
-                    $existingTmKey = $existingTmKeys->get($existingTmKeyKey);
-                    $existingTmKey->fill($receivedTmKeysData->get($existingTmKeyKey))
-                        ->saveOrFail();
-                });
-
             // Delete missing
             if (! empty($tmKeysToRemove = $existingTmKeys->keys()->diff($receivedTmKeysData->keys())->toArray())) {
                 CatToolTmKey::whereIn('key', $tmKeysToRemove)
@@ -136,6 +128,27 @@ class CatToolTmKeyController extends Controller
 
             return CatToolTmKeyResource::collection($subProject->catToolTmKeys()->get());
         });
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[OA\Put(
+        path: '/tm-keys/toggle-writable/{id}',
+        summary: 'Mark/Unmark TM key as writable for the sub-project',
+        requestBody: new OAH\RequestBody(CatToolTmKeysSyncRequest::class),
+        tags: ['TM keys'],
+        responses: [new OAH\NotFound, new OAH\Forbidden, new OAH\Unauthorized, new OAH\InvalidTmKeys]
+    )]
+    public function toggleWritable(CatToolTmKeyToggleIsWritableRequest $request): CatToolTmKeyResource
+    {
+        /** @var CatToolTmKey $tmKey */
+        $tmKey = self::getBaseQuery()->findOrFail($request->route('id'));
+        $this->authorize('toggleWritable', $tmKey);
+        $tmKey->fill($request->validated());
+        $tmKey->saveOrFail();
+
+        return CatToolTmKeyResource::make($tmKey);
     }
 
     private static function getBaseQuery(): Builder

--- a/application/app/Http/Controllers/API/VendorController.php
+++ b/application/app/Http/Controllers/API/VendorController.php
@@ -22,6 +22,7 @@ class VendorController extends Controller
 {
     /**
      * Display a listing of the resource.
+     *
      * @throws AuthorizationException
      */
     #[OA\Get(
@@ -126,6 +127,7 @@ class VendorController extends Controller
 
     /**
      * Update the specified resource in storage.
+     *
      * @throws AuthorizationException
      * @throws \Throwable
      */
@@ -196,6 +198,7 @@ class VendorController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     *
      * @throws \Throwable
      */
     #[OA\Post(
@@ -229,6 +232,7 @@ class VendorController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     *
      * @throws \Throwable
      */
     #[OA\Delete(

--- a/application/app/Http/Requests/API/CatToolSetupRequest.php
+++ b/application/app/Http/Requests/API/CatToolSetupRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests\API;
 
 use App\Models\Media;
-use App\Models\Project;
 use App\Models\SubProject;
 use App\Policies\SubProjectPolicy;
 use App\Rules\SubProjectExistsRule;

--- a/application/app/Http/Requests/API/CatToolTmKeyToggleIsWritableRequest.php
+++ b/application/app/Http/Requests/API/CatToolTmKeyToggleIsWritableRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\API;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CatToolTmKeyToggleIsWritableRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'is_writable' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/application/app/Http/Requests/API/CatToolTmKeysSyncRequest.php
+++ b/application/app/Http/Requests/API/CatToolTmKeysSyncRequest.php
@@ -25,10 +25,9 @@ use OpenApi\Attributes as OA;
                 property: 'tm_keys',
                 type: 'array',
                 items: new OA\Items(
-                    required: ['key', 'is_writable'],
+                    required: ['key'],
                     properties: [
                         new OA\Property(property: 'key', type: 'string'),
-                        new OA\Property(property: 'is_writable', type: 'boolean'),
                     ],
                     type: 'object'
                 ),
@@ -56,7 +55,6 @@ class CatToolTmKeysSyncRequest extends FormRequest
             ],
             'tm_keys' => ['present', 'array', 'max:10'],
             'tm_keys.*.key' => ['required', 'string'],
-            'tm_keys.*.is_writable' => ['required', 'boolean'],
         ];
     }
 
@@ -66,15 +64,6 @@ class CatToolTmKeysSyncRequest extends FormRequest
             function (Validator $validator): void {
                 if ($validator->errors()->isNotEmpty()) {
                     return;
-                }
-
-                $writeTmCount = array_sum($this->validated('tm_keys.*.is_writable'));
-                if ($writeTmCount === 0) {
-                    $validator->errors()->add('tm_keys', 'At least one TM should be writable');
-                }
-
-                if ($writeTmCount > 2) {
-                    $validator->errors()->add('tm_keys', 'Not more than two translation memories can be writable');
                 }
 
                 $subProject = SubProject::withGlobalScope('policy', SubProjectPolicy::scope())

--- a/application/app/Http/Resources/API/CandidateResource.php
+++ b/application/app/Http/Resources/API/CandidateResource.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Resources\API;
 
-use App\Models\Assignment;
 use App\Models\Candidate;
-use App\Models\Vendor;
 use App\Services\Prices\CandidatePriceCalculator;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/application/app/Models/Dto/VolumeAnalysisDiscount.php
+++ b/application/app/Models/Dto/VolumeAnalysisDiscount.php
@@ -7,12 +7,19 @@ use JsonSerializable;
 class VolumeAnalysisDiscount implements JsonSerializable
 {
     public ?float $discount_percentage_101;
+
     public ?float $discount_percentage_repetitions;
+
     public ?float $discount_percentage_100;
+
     public ?float $discount_percentage_95_99;
+
     public ?float $discount_percentage_85_94;
+
     public ?float $discount_percentage_75_84;
+
     public ?float $discount_percentage_50_74;
+
     public ?float $discount_percentage_0_49;
 
     public function __construct(array $params)

--- a/application/app/Policies/CatToolTmKeyPolicy.php
+++ b/application/app/Policies/CatToolTmKeyPolicy.php
@@ -44,6 +44,16 @@ class CatToolTmKeyPolicy
     }
 
     /**
+     * @return bool
+     *
+     * TODO: set correct permission check
+     */
+    public function toggleWritable(JwtPayloadUser $user, CatToolTmKey $tmKey): bool
+    {
+        return Gate::allows('update', [$tmKey->subProject->project]);
+    }
+
+    /**
      * Determine whether the user can update the model.
      */
     public function update(JwtPayloadUser $user, CatToolTmKey $catToolTm): bool

--- a/application/app/Policies/SubProjectPolicy.php
+++ b/application/app/Policies/SubProjectPolicy.php
@@ -22,7 +22,6 @@ class SubProjectPolicy
     }
 
     /**
-     * @param JwtPayloadUser $user
      * @return mixed
      *
      * TODO: add correct privilege check

--- a/application/routes/api.php
+++ b/application/routes/api.php
@@ -83,6 +83,7 @@ Route::prefix('/tm-keys')
         Route::get('/{sub_project_id}', 'index');
         Route::get('/subprojects/{key}', 'subProjectsIndex');
         Route::post('/sync', 'sync');
+        Route::put('/toggle-writable/{id}', 'toggleWritable');
     });
 
 Route::prefix('/volumes')


### PR DESCRIPTION
- Moved logic of marking the TM as writable to separate endpoint
- Moved validation of a sub-project TM keys amount to `/cat-tool/setup` endpoint.