### PR TITLE
hotfix - add calculation of the subproject statuses synchronously

### DIFF
--- a/application/app/Http/Controllers/API/AssignmentController.php
+++ b/application/app/Http/Controllers/API/AssignmentController.php
@@ -420,7 +420,8 @@ class AssignmentController extends Controller
                 $assignment->saveOrFail();
             });
 
-            TrackSubProjectStatus::dispatch($assignment->subProject);
+            TrackSubProjectStatus::dispatchSync($assignment->subProject);
+            $assignment->load('subProject');
 
             return AssignmentResource::make($assignment);
         });

--- a/application/app/Http/Controllers/API/SubProjectController.php
+++ b/application/app/Http/Controllers/API/SubProjectController.php
@@ -218,6 +218,7 @@ class SubProjectController extends Controller
         }
 
         $subProject->workflow()->start();
+        $subProject->refresh();
         return SubProjectResource::make($subProject);
     }
 

--- a/application/app/Http/Controllers/API/WorkflowController.php
+++ b/application/app/Http/Controllers/API/WorkflowController.php
@@ -262,7 +262,9 @@ class WorkflowController extends Controller
             WorkflowService::setAssignee($taskId, $activeVendor->institution_user_id);
         });
 
-        TrackSubProjectStatus::dispatch($assignment->subProject);
+        TrackSubProjectStatus::dispatchSync($assignment->subProject);
+        $assignment->load('subProject');
+
         return TaskResource::make($taskData);
     }
 
@@ -373,10 +375,11 @@ class WorkflowController extends Controller
             });
 
 
-            TrackSubProjectStatus::dispatch($assignment->subProject);
+            TrackSubProjectStatus::dispatchSync($assignment->subProject);
+            $assignment->load('subProject');
         } elseif (filled($project = $this->getTaskProject($taskData))) {
             WorkflowService::completeTask($taskId);
-            TrackProjectStatus::dispatch($project);
+            TrackProjectStatus::dispatchSync($project);
         } else {
             abort(Response::HTTP_INTERNAL_SERVER_ERROR, 'The task metadata is missing');
         }
@@ -422,7 +425,8 @@ class WorkflowController extends Controller
             WorkflowService::completeReviewTask(data_get($taskData, 'task.id'), $validated['accepted']);
         });
 
-        TrackSubProjectStatus::dispatch($assignment->subProject);
+        TrackSubProjectStatus::dispatchSync($assignment->subProject);
+        $assignment->load('subProject');
 
         return TaskResource::make($taskData);
     }
@@ -482,7 +486,7 @@ class WorkflowController extends Controller
         });
 
 
-        TrackProjectStatus::dispatch($project);
+        TrackProjectStatus::dispatchSync($project);
 
         return TaskResource::make($taskData);
     }

--- a/application/app/Jobs/Workflows/TrackSubProjectStatus.php
+++ b/application/app/Jobs/Workflows/TrackSubProjectStatus.php
@@ -56,7 +56,7 @@ class TrackSubProjectStatus implements ShouldQueue
                 $this->subProject->active_job_definition_id = null;
                 $this->subProject->saveOrFail();
 
-                TrackProjectStatus::dispatch($this->subProject->project);
+                TrackProjectStatus::dispatchSync($this->subProject->project);
                 return;
             }
 
@@ -156,7 +156,7 @@ class TrackSubProjectStatus implements ShouldQueue
 
     private function hasAssigneeForAllAssignments(JobDefinition $jobDefinition): bool
     {
-        return $this->subProject->assignments()
+        return !$this->subProject->assignments()
             ->where('job_definition_id', $jobDefinition->id)
             ->whereNull('assigned_vendor_id')
             ->exists();

--- a/application/app/Services/Workflows/SubProjectWorkflowProcessInstance.php
+++ b/application/app/Services/Workflows/SubProjectWorkflowProcessInstance.php
@@ -55,7 +55,7 @@ readonly class SubProjectWorkflowProcessInstance
             $this->subProject->workflow_started = true;
             $this->subProject->saveOrFail();
 
-            TrackSubProjectStatus::dispatch($this->subProject);
+            TrackSubProjectStatus::dispatchSync($this->subProject);
         } catch (RequestException $e) {
             throw new RuntimeException("Starting of the sub-project workflow failed", $e->response->status(), $e);
         }


### PR DESCRIPTION
I discussed with @KaarelKa that delayed status calculation requires FE to re-fetch sub-project info. I changed the status calculation logic to make it work in a sync way, to prevent overloading with re-fetching (much simpler for the FE). The change may slowdowns down the endpoints that affect sub-project statuses, but it can be the place for improvements in the next phases in case if it will be needed.

The PR also contains bug fix for status calculation.