### PR TITLE
Final files management

### DIFF
--- a/application/app/Http/Controllers/API/AssignmentController.php
+++ b/application/app/Http/Controllers/API/AssignmentController.php
@@ -400,10 +400,10 @@ class AssignmentController extends Controller
 
                 WorkflowService::completeReviewTask($taskId, $validated['accepted']);
                 try {
-                    $validated['accepted'] && $assignment->subProject
-                        ->moveFinalFilesToProjectFinalFiles(
-                            $validated['final_file_id']
-                        );
+                    $validated['accepted'] && $assignment->subProject->syncFinalFilesWithProject(
+                        $validated['final_file_id']
+                    );
+
                 } catch (InvalidArgumentException $e) {
                     abort(Response::HTTP_BAD_REQUEST, $e->getMessage());
                 }

--- a/application/app/Http/Controllers/API/MediaController.php
+++ b/application/app/Http/Controllers/API/MediaController.php
@@ -6,13 +6,13 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\API\MediaCreateRequest;
 use App\Http\Requests\API\MediaDeleteRequest;
 use App\Http\Requests\API\MediaDownloadRequest;
+use App\Http\Requests\MediaUpdateRequest;
 use App\Http\Resources\MediaResource;
 use App\Models\Media;
 use App\Models\Project;
 use App\Models\SubProject;
 use Auth;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use OpenApi\Attributes as OA;
 use App\Http\OpenApiHelpers as OAH;
@@ -90,6 +90,44 @@ class MediaController extends Controller
 
             return MediaResource::collection($data);
         });
+    }
+
+    /**
+     * @throws AuthorizationException
+     * @throws Throwable
+     */
+    #[OA\Put(
+        path: '/media/{id}',
+        summary: 'Update the media.Currently can be used only for updating of the help files types.',
+        requestBody: new OAH\RequestBody(MediaUpdateRequest::class),
+        tags: ['Media'],
+        responses: [new OAH\Forbidden, new OAH\Unauthorized, new OAH\Invalid]
+    )]
+    #[OAH\ResourceResponse(dataRef: MediaResource::class, description: 'Updated Media', response: Response::HTTP_OK)]
+    public function update(MediaUpdateRequest $request): MediaResource
+    {
+        return DB::transaction(function () use ($request) {
+            $media = Media::findOrFail($request->route('id'));
+
+            if ($media->collection_name !== Project::HELP_FILES_COLLECTION) {
+                abort(Response::HTTP_BAD_REQUEST, 'Only help files can be updated');
+            }
+
+            [$entity, ,] = $this->determineEntityAndCollectionName(
+                $media->model_type,
+                $media->model_id,
+                $media->collection_name
+            );
+
+            $ability = $this->determineAuthorizationAbility($entity, $media->collection_name);
+            $this->authorize($ability, $entity);
+
+            $media->setCustomProperty('type', $request->validated('help_file_type'));
+            $media->saveOrFail();
+
+            return MediaResource::make($media);
+        });
+
     }
 
     /**
@@ -171,8 +209,8 @@ class MediaController extends Controller
     private function determineEntityAndCollectionName(string $referenceObjectType, string $referenceObjectId, $collection): ?array
     {
         $entityClass = match ($referenceObjectType) {
-            'project' => Project::class,
-            'subproject' => SubProject::class,
+            'project', Project::class => Project::class,
+            'subproject', SubProject::class => SubProject::class,
             default => null,
         };
 
@@ -185,11 +223,11 @@ class MediaController extends Controller
             return null;
         }
 
-        return match ([$referenceObjectType, $collection]) {
-            ['project', 'source'] => [$entity, $entity, Project::SOURCE_FILES_COLLECTION],
-            ['project', 'help'] => [$entity, $entity, Project::HELP_FILES_COLLECTION],
-            ['subproject', 'source'] => [$entity, $entity->project, $entity->file_collection],
-            ['subproject', 'final'] => [$entity, $entity->project, $entity->file_collection_final],
+        return match ([$entityClass, $collection]) {
+            [Project::class, 'source'] => [$entity, $entity, Project::SOURCE_FILES_COLLECTION],
+            [Project::class, 'help'] => [$entity, $entity, Project::HELP_FILES_COLLECTION],
+            [SubProject::class, 'source'] => [$entity, $entity->project, $entity->file_collection],
+            [SubProject::class, 'final'] => [$entity, $entity->project, $entity->file_collection_final],
             default => null,
         };
     }

--- a/application/app/Http/Requests/API/SetProjectFinalFilesRequest.php
+++ b/application/app/Http/Requests/API/SetProjectFinalFilesRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\API;
+
+use App\Models\Media;
+use App\Models\SubProject;
+use App\Policies\SubProjectPolicy;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class SetProjectFinalFilesRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'final_file_id' => ['array'],
+            'final_file_id.*' => [
+                'required',
+                'integer',
+                Rule::exists(Media::class, 'id'),
+            ],
+        ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                if ($validator->errors()->isNotEmpty()) {
+                    return;
+                }
+
+                $subProject = SubProject::withGlobalScope('policy', SubProjectPolicy::scope())->find($this->route('id'));
+                if (empty($subProject)) {
+                    return;
+                }
+
+                $subProjectFinalFilesIds = $subProject->finalFiles->pluck('id');
+                collect($this->validated('final_file_id'))->each(function (int $finalFileId, int $idx) use ($subProjectFinalFilesIds, $validator) {
+                    if (! $subProjectFinalFilesIds->contains($finalFileId)) {
+                        $validator->errors()->add("final_file_id.$idx", 'The file is not subproject final file');
+                    }
+                });
+            }
+        ];
+    }
+}

--- a/application/app/Http/Requests/MediaUpdateRequest.php
+++ b/application/app/Http/Requests/MediaUpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Project;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use OpenApi\Attributes as OA;
+
+#[OA\RequestBody(
+    request: self::class,
+    required: true,
+    content: new OA\JsonContent(
+        required: ['help_file_type'],
+        properties: [
+            new OA\Property(property: 'help_file_type', type: 'string', enum: Project::HELP_FILE_TYPES),
+        ]
+    )
+)]
+class MediaUpdateRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'help_file_type' => ['required', Rule::in(Project::HELP_FILE_TYPES)]
+        ];
+    }
+}

--- a/application/app/Http/Resources/MediaResource.php
+++ b/application/app/Http/Resources/MediaResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Http\Resources\API\AssignmentResource;
 use App\Models\Media;
 use App\Models\Project;
 use Illuminate\Http\Request;
@@ -23,6 +24,8 @@ use OpenApi\Attributes as OA;
             property: 'custom_properties',
             properties: [
                 new OA\Property(property: 'type', type: 'string', enum: Project::HELP_FILE_TYPES),
+                new OA\Property(property: 'assignment_id', type: 'string', format: 'uuid', nullable: true),
+                new OA\Property(property: 'institution_user_id', type: 'string', format: 'uuid', nullable: true),
             ],
             type: 'object'),
         new OA\Property(property: 'size', type: 'integer'),
@@ -37,6 +40,8 @@ use OpenApi\Attributes as OA;
         ),
         new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
         new OA\Property(property: 'updated_at', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'assignment', ref: AssignmentResource::class, nullable: true),
+        new OA\Property(property: 'is_project_final_file', type: 'boolean', nullable: true),
     ],
     type: 'object'
 )]
@@ -49,16 +54,31 @@ class MediaResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return $this->only(
-            'name',
-            'id',
-            'uuid',
-            'file_name',
-            'custom_properties',
-            'size',
-            'collection_name',
-            'created_at',
-            'updated_at',
-        );
+        return [
+            ...$this->only(
+                'name',
+                'id',
+                'uuid',
+                'file_name',
+                'custom_properties',
+                'size',
+                'collection_name',
+                'created_at',
+                'updated_at',
+            ),
+            'assignment' => AssignmentResource::make($this->whenLoaded('assignment')),
+            ...$this->getSubProjectFinalFileIsProjectFinalFileField()
+        ];
+    }
+
+    private function getSubProjectFinalFileIsProjectFinalFileField(): array
+    {
+        if ($this->relationLoaded('copies')) {
+            return [
+                'is_project_final_file' => $this->copies->contains(fn (Media $media) => $media->isProjectFinalFile())
+            ];
+        }
+
+        return [];
     }
 }

--- a/application/app/Models/MediaCopy.php
+++ b/application/app/Models/MediaCopy.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\MediaObserver;
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
+
+/**
+ * The table is needed to store relations between files as one file can be copied to different collections.
+ *
+ * Example: We store source files inside the Project source files collection and SubProjects source files collection.
+ * Use case: When project source file was removed we have to remove the file from all subprojects source files.
+ *
+ * @see Project::initSubProjects()
+ * @see SubProject::syncFinalFilesWithProject()
+ * @see MediaObserver
+ *
+ * App\Models\MediaCopy
+ *
+ * @property string $source_media_id
+ * @property string $copy_media_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @method static Builder|MediaCopy newModelQuery()
+ * @method static Builder|MediaCopy newQuery()
+ * @method static Builder|MediaCopy query()
+ * @method static Builder|MediaCopy whereCopyMediaId($value)
+ * @method static Builder|MediaCopy whereCreatedAt($value)
+ * @method static Builder|MediaCopy whereSourceMediaId($value)
+ * @method static Builder|MediaCopy whereUpdatedAt($value)
+ * @method static Builder|MediaCopy whereUuid($value)
+ *
+ * @mixin Eloquent
+ */
+class MediaCopy extends Pivot
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'media_copies';
+
+    public function copy(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'copy_media_id', 'uuid');
+    }
+
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Media::class, 'source_media_id', 'uuid');
+    }
+}

--- a/application/app/Models/Project.php
+++ b/application/app/Models/Project.php
@@ -234,7 +234,9 @@ class Project extends Model implements HasMedia
             $subProject->saveOrFail();
 
             $this->getMedia('source')->each(function ($sourceFile) use ($subProject) {
-                $sourceFile->copy($this, $subProject->file_collection);
+                /** @var Media $sourceFile */
+                $copiedFile = $sourceFile->copy($this, $subProject->file_collection);
+                $sourceFile->copies()->save($copiedFile);
             });
 
             $subProject->initAssignments();

--- a/application/app/Models/SubProject.php
+++ b/application/app/Models/SubProject.php
@@ -24,9 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
-use InvalidArgumentException;
 use RuntimeException;
-use Spatie\MediaLibrary\InteractsWithMedia;
 use Staudenmeir\EloquentHasManyDeep\Eloquent\CompositeKey;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Staudenmeir\EloquentHasManyDeep\HasOneDeep;
@@ -192,66 +190,32 @@ class SubProject extends Model
         });
     }
 
-    public function moveFinalFilesToProjectFinalFiles($finalFilesIds): void
-    {
-        if (empty($finalFilesIds)) {
-            throw new InvalidArgumentException('No final files specified');
-        }
-
-
-        $files = $this->finalFiles->filter(fn(Media $media) => in_array($media->id, $finalFilesIds))
-            ->values();
-
-        $wrongFilesPassed = $files->count() !== count($finalFilesIds);
-
-        if ($wrongFilesPassed) {
-            throw new InvalidArgumentException('Files IDs are incorrect');
-        }
-
-        $project = $this->project;
-        $files->each(function (Media $media) use ($project) {
-            /** @var Media $projectMedia */
-            $projectMedia = $media->copy($project, Project::FINAL_FILES_COLLECTION);
-            $projectMedia->setCustomProperty('source_media_id', $media->id);
-            $projectMedia->save();
-
-            $media->setCustomProperty('copy_media_id', $projectMedia->id)
-                ->setCustomProperty('project_source_file', true)
-                ->setCustomProperty('sub_project_id', $this->id);
-
-            $media->save();
-        });
-    }
-
     /**
      * @throws Throwable
      */
     public function syncFinalFilesWithProject($subProjectFinalFileIds): void
     {
         $subProjectFinalFileIds = collect($subProjectFinalFileIds);
-        $projectFinalFiles = $this->project->getMedia(
-            Project::FINAL_FILES_COLLECTION,
-            ['sub_project_id' => $this->id]
-        );
+        $subProjectProjectFinalFileIds = $this->finalFiles->filter(function (Media $media) {
+            return $media->copies->contains(fn (Media $copiedMedia) => $copiedMedia->isProjectFinalFile());
+        })->values()->pluck('id');
 
-        $actualSubProjectFinalFileIds = $projectFinalFiles->map(
-            fn(Media $media) => $media->getCustomProperty('source_media_id')
-        );
 
-        $toCreate = $subProjectFinalFileIds->diff($actualSubProjectFinalFileIds);
-        $toDelete = $actualSubProjectFinalFileIds->diff($subProjectFinalFileIds);
+        $toCreate = $subProjectFinalFileIds->diff($subProjectProjectFinalFileIds);
+        $toDelete = $subProjectProjectFinalFileIds->diff($subProjectFinalFileIds);
 
         if ($toCreate->isNotEmpty()) {
-            $this->finalFiles->filter(fn (Media $media) => $toCreate->contains($media->id))
-                ->each(function (Media $media) {
-                    $media->moveToProjectFinalFile($this);
+            $this->finalFiles->filter(fn(Media $media) => $toCreate->contains($media->id))
+                ->each(function (Media $sourceFile) {
+                    $copiedFile = $sourceFile->copy($this->project, Project::FINAL_FILES_COLLECTION);
+                    $sourceFile->copies()->save($copiedFile);
                 });
         }
 
         if ($toDelete->isNotEmpty()) {
-            $projectFinalFiles->filter(
-                fn (Media $media) => $toDelete->contains($media->getCustomProperty('source_media_id'))
-            )->each(function (Media $media) {
+            $this->project->getMedia(Project::FINAL_FILES_COLLECTION, function (Media $media) use ($toDelete) {
+                return $media->sources->pluck('id')->intersect($toDelete)->isNotEmpty();
+            })->each(function (Media $media) {
                 $media->delete();
             });
         }

--- a/application/app/Observers/MediaObserver.php
+++ b/application/app/Observers/MediaObserver.php
@@ -23,14 +23,12 @@ class MediaObserver
     }
 
     /**
-     * Handle the Media "deleted" event.
+     * Handle the Media "deleting" event.
      */
-    public function deleted(Media $media): void
+    public function deleting(Media $media): void
     {
-        if ($media->hasCustomProperty('copy_media_id')) {
-            if (filled($copiedMedia = Media::find($media->getCustomProperty('copy_media_id')))) {
-                $copiedMedia->delete();
-            }
+        if ($media->copies->isNotEmpty()) {
+            $media->copies->each(fn (Media $media) => $media->delete());
         }
     }
 }

--- a/application/app/Observers/MediaObserver.php
+++ b/application/app/Observers/MediaObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Media;
+
+class MediaObserver
+{
+    /**
+     * Handle the Media "created" event.
+     */
+    public function created(Media $media): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Media "updated" event.
+     */
+    public function updated(Media $media): void
+    {
+        //
+    }
+
+    /**
+     * Handle the Media "deleted" event.
+     */
+    public function deleted(Media $media): void
+    {
+        if ($media->hasCustomProperty('copy_media_id')) {
+            if (filled($copiedMedia = Media::find($media->getCustomProperty('copy_media_id')))) {
+                $copiedMedia->delete();
+            }
+        }
+    }
+}

--- a/application/app/Policies/SubProjectPolicy.php
+++ b/application/app/Policies/SubProjectPolicy.php
@@ -94,6 +94,11 @@ class SubProjectPolicy
         return $this->hasManageProjectPrivilege($subProject);
     }
 
+    public function markFilesAsProjectFinalFiles(JwtPayloadUser $user, SubProject $subProject): bool
+    {
+        return $this->hasManageProjectPrivilege($subProject);
+    }
+
     private function hasManageProjectPrivilege(SubProject $subProject): bool
     {
         if (! $this->isInSameInstitutionAsCurrentUser($subProject)) {

--- a/application/app/Providers/EventServiceProvider.php
+++ b/application/app/Providers/EventServiceProvider.php
@@ -60,6 +60,7 @@ class EventServiceProvider extends ServiceProvider
         Models\CachedEntities\Institution::observe(Observers\InstitutionObserver::class);
         Models\AssignmentCatToolJob::observe(Observers\AssignmentCatToolJobObserver::class);
         Models\ProjectReviewRejection::observe(Observers\ProjectReviewRejectionObserver::class);
+        Models\Media::observe(Observers\MediaObserver::class);
     }
 
     /**

--- a/application/database/migrations/2023_11_28_094818_create_media_copies_table.php
+++ b/application/database/migrations/2023_11_28_094818_create_media_copies_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('media_copies', function (Blueprint $table) {
+            $table->foreignUuid('source_media_id')->constrained('media', 'uuid')->onDelete('CASCADE');
+            $table->foreignUuid('copy_media_id')->constrained('media', 'uuid')->onDelete('CASCADE');
+            $table->timestampsTz();
+            $table->unique(['source_media_id', 'copy_media_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('media_copies');
+    }
+};

--- a/application/routes/api.php
+++ b/application/routes/api.php
@@ -68,6 +68,7 @@ Route::prefix('/subprojects')
         Route::get('/', 'index');
         Route::get('/{id}', 'show');
         Route::post('/{id}/start-workflow', 'startWorkflow');
+        Route::post('/{id}/set-project-final-files', 'setProjectFinalFiles');
     });
 
 Route::prefix('/cat-tool')

--- a/application/routes/api.php
+++ b/application/routes/api.php
@@ -132,11 +132,11 @@ Route::prefix('/workflow')
 
 Route::prefix('/media')
     ->controller(API\MediaController::class)
-    ->whereUuid('id')
     ->group(function () {
         Route::post('/bulk', 'bulkStore');
         Route::delete('/bulk', 'bulkDestroy');
         Route::get('/download', 'download');
+        Route::put('/{id}', 'update');
     });
 
 // ??


### PR DESCRIPTION
### Functionalities
- Marking sub-project final files as project final files.
- Updating of help file types (https://github.com/keeleinstituut/tv-tolkevarav/issues/561)
-  Improved files consistency: 
    - when adding a project source file it will be added to sub-projects as source file.
    - when removing a project source file it will be removed from sub-projects source files.
    - when removing a sub-project final file it will be removed from the project final files.

### API
New endpoints:
- PUT `/media/{id}`
- POST `subprojects/{id}/set-project-final-files`

Updated resources:
- MediaResource:
    - added `assignment` field that contains `AssignmentResource` with `JobDefinitionResource`.
    - added `is_project_final_file` field.