### PR TITLE
hotfix - Add data from translation memory service 

### DIFF
--- a/application/app/Http/Controllers/API/CatToolTmKeyController.php
+++ b/application/app/Http/Controllers/API/CatToolTmKeyController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\API\CatToolTmKeysSyncRequest;
 use App\Http\Requests\API\CatToolTmKeyToggleIsWritableRequest;
 use App\Http\Requests\API\TmKeySubProjectListRequest;
 use App\Http\Resources\API\CatToolTmKeyResource;
+use App\Http\Resources\API\CreatedCatToolTmKeyResource;
 use App\Http\Resources\API\SubProjectResource;
 use App\Models\CatToolTmKey;
 use App\Models\SubProject;
@@ -179,8 +180,8 @@ class CatToolTmKeyController extends Controller
         tags: ['TM keys'],
         responses: [new OAH\NotFound, new OAH\Forbidden, new OAH\Unauthorized, new OAH\InvalidTmKeys]
     )]
-    #[OAH\ResourceResponse(dataRef: CatToolTmKeyResource::class, description: 'Created TM key', response: Response::HTTP_CREATED)]
-    public function create(Request $request): CatToolTmKeyResource
+    #[OAH\ResourceResponse(dataRef: CreatedCatToolTmKeyResource::class, description: 'Created TM key', response: Response::HTTP_CREATED)]
+    public function create(Request $request): CreatedCatToolTmKeyResource
     {
         $subProject = SubProject::withGlobalScope('policy', SubProjectPolicy::scope())
             ->findOrFail($request->route('sub_project_id'));
@@ -216,7 +217,10 @@ class CatToolTmKeyController extends Controller
                     ])
                 );
 
-                return CatToolTmKeyResource::make($tmKey->refresh());
+                return CreatedCatToolTmKeyResource::make([
+                    'key' => $tmKey->refresh(),
+                    'meta' => $tmKeyData
+                ]);
             } catch (InvalidArgumentException $e) {
                 abort(Response::HTTP_BAD_REQUEST, $e->getMessage());
             } catch (RequestException $e) {

--- a/application/app/Http/Resources/API/CreatedCatToolTmKeyResource.php
+++ b/application/app/Http/Resources/API/CreatedCatToolTmKeyResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources\API;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    title: 'CatToolTm',
+    required: [
+        'cat_tm_key',
+        'cat_tm_meta'
+    ],
+    properties: [
+        new OA\Property(property: 'cat_tm_key', ref: CatToolTmKeyResource::class),
+        new OA\Property(property: 'cat_tm_meta', description: 'The response from creating TM inside TM service', type: 'object'),
+    ],
+    type: 'object'
+)]
+class CreatedCatToolTmKeyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'cat_tm_key' => CatToolTmKeyResource::make(data_get($this, 'key')),
+            'cat_tm_meta' => data_get($this, 'meta'),
+        ];
+    }
+}


### PR DESCRIPTION
Added data from the translation memory service to create an empty TM endpoint response.